### PR TITLE
Made Configuration ignore a few common options

### DIFF
--- a/src/main/groovy/org/springdoclet/Configuration.groovy
+++ b/src/main/groovy/org/springdoclet/Configuration.groovy
@@ -10,6 +10,13 @@ class Configuration {
   private static final String DEFAULT_STYLESHEET = './spring-summary.css'
   private static final String DEFAULT_LINKPATH = './'
 
+  // List of ignored options
+  // TODO: Implement support for these since they are considered standard options
+  private static final Map IGNORED_OPTIONS = [ 
+    '-doctitle': 2,
+    '-windowtitle': 2,
+  ]
+
   String[][] options
 
   def getOutputDirectory() {
@@ -50,6 +57,8 @@ class Configuration {
       return 2
     } else if (option.equals(OPTION_LINKPATH)) {
       return 2
+    } else if (IGNORED_OPTIONS.containsKey(option)) {
+      return IGNORED_OPTIONS[option]
     }
     return 0
   }


### PR DESCRIPTION
Gradle passes the -doctitle and -windowtitle options to all doclets which causes this doclet to fail if executed by gradle. By accepting these options (returning a proper length in getOptionLength) the doclet can run under gradle even if these options are present.
