### PR TITLE
Fix for Issue#3 - Add Gradle example

### DIFF
--- a/src/main/groovy/org/springdoclet/SpringDoclet.groovy
+++ b/src/main/groovy/org/springdoclet/SpringDoclet.groovy
@@ -1,13 +1,13 @@
 package org.springdoclet
 
-import com.sun.javadoc.Doclet
 import com.sun.javadoc.RootDoc
+import com.sun.tools.doclets.standard.Standard
 import org.springdoclet.writers.StylesheetWriter
 import org.springdoclet.writers.HtmlWriter
 import org.springdoclet.collectors.RequestMappingCollector
 import org.springdoclet.collectors.ComponentCollector
 
-class SpringDoclet extends Doclet {
+class SpringDoclet extends Standard{
   private static Configuration config = new Configuration()
 
   public static boolean start(RootDoc root) {


### PR DESCRIPTION
As part of the fix, I changed SpringDoclet to extend from Standard instead of Doclet to get rid of the invalid flag issue mentioned in the issue comments.

Ran tests with a SpringMVC app running on gradle and it worked fine.
