### PR TITLE
Concatenation of class and method level RequestMapping

### DIFF
--- a/src/main/groovy/org/springdoclet/collectors/RequestMappingCollector.groovy
+++ b/src/main/groovy/org/springdoclet/collectors/RequestMappingCollector.groovy
@@ -41,8 +41,13 @@ class RequestMappingCollector implements Collector {
   private def processMethod(classDoc, methodDoc, rootPath, defaultHttpMethods, annotation) {
     def (path, httpMethods) = getMappingElements(annotation)
     for (httpMethod in (httpMethods ?: defaultHttpMethods)) {
-      addMapping classDoc, methodDoc, "$rootPath$path", httpMethod
+	addMapping classDoc, methodDoc, concatenatePaths(rootPath, path), httpMethod    
     }
+
+  }
+
+  private def concatenatePaths(rootPath, path) {
+	return "$rootPath$path".replaceAll("\"\"", "/").replaceAll("//", "/")
   }
 
   private def getMappingAnnotation(annotations) {


### PR DESCRIPTION
When RequestMapping annotation is available at both class and method level, it is concatenated directly yielding to incorrect path display. For example, if the class level is annotated as _@RequestMapping(value = "/api/users", method = RequestMethod.GET)_ and method level as _@RequestMapping(value = "/all", method = RequestMethod.GET)_, the doclet was printing the path as _"/api/users""/all"_. This fix is to address this scenario.

The following scenarios are corrected.
1. Handle scenarios where "/" is included in the method annotations. Example - _"/api/users""/all"_ is corrected to _"/api/users/all"_
2. Handle scenarios where "/" is not included in the method annotations. Example - _"/api/users""all"_ is corrected to _"/api/users/all"_
